### PR TITLE
Add Directory Path Argument Support To `dirtree`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dirtree
 
-This package prints the directory tree of the current directory respecting your `.gitignore` file.
+This package prints the directory tree of the current directory, or the directory tree of the directory path specified as a command line argument respecting your `.gitignore` file.
 
 ## Installation
 
@@ -12,10 +12,10 @@ go install github.com/datumbrain/dirtree@latest
 
 ## Usage
 
-Go to any directory and run the following command to print the directory tree
+Run the command with the path of the directory as a command line argument to print the directory tree of specified directory. If no argument is specified then the directory tree of the current directory will be printed.
 
 ```bash
-dirtree
+dirtree [directory]
 ```
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ go install github.com/datumbrain/dirtree@latest
 
 ## Usage
 
-Run the command with the path of the directory as a command line argument to print the directory tree of specified directory. If no argument is specified then the directory tree of the current directory will be printed.
+Run the command with the path of the directory as a command line argument to print the directory tree of specified directory. If no argument is specified then the directory tree of the current directory will be printed. To print the version of dirtree use -v or --version as an argument.
 
 ```bash
-dirtree [directory ...]
+dirtree [directory | -v | --version]
 ```
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ go install github.com/datumbrain/dirtree@latest
 Run the command with the path of the directory as a command line argument to print the directory tree of specified directory. If no argument is specified then the directory tree of the current directory will be printed.
 
 ```bash
-dirtree [directory]
+dirtree [directory ...]
 ```
 
 ## Authors

--- a/dirtree.go
+++ b/dirtree.go
@@ -4,15 +4,26 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	gitignore "github.com/sabhiram/go-gitignore"
 )
 
 func main() {
-	rootDir := "."
+	var rootDir string
+
+	if len(os.Args) == 2 {
+		rootDir = strings.Join(os.Args[1:2], "")
+	} else if len(os.Args) > 2 {
+		fmt.Printf("Invalid number of arguments")
+		os.Exit(1)
+	} else {
+		rootDir = "."
+	}
 
 	fmt.Println(".")
 	printTree(rootDir, "", nil)
+
 }
 
 func shouldIgnore(path string, ignoreMatchers []*gitignore.GitIgnore) bool {

--- a/dirtree.go
+++ b/dirtree.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	gitignore "github.com/sabhiram/go-gitignore"
 )
@@ -17,17 +16,18 @@ func main() {
 		rootDir = "."
 		fmt.Println(".")
 	case 2:
-		rootDir = strings.Join(os.Args[1:2], "")
+		rootDir = os.Args[1]
 		_, err := os.Stat(rootDir)
 		if os.IsNotExist(err) {
-			fmt.Println("File does not exist")
+			fmt.Println("directory does not exist")
 			os.Exit(1)
 		}
 		if err != nil {
-			fmt.Printf("Error %v", err)
+			fmt.Println(fmt.Errorf("error: %v", err))
+			os.Exit(1)
 		}
 	default:
-		fmt.Printf("Usage: dirtree [directory]")
+		fmt.Println("Usage: dirtree [directory]")
 		os.Exit(1)
 	}
 

--- a/dirtree.go
+++ b/dirtree.go
@@ -12,18 +12,26 @@ import (
 func main() {
 	var rootDir string
 
-	if len(os.Args) == 2 {
-		rootDir = strings.Join(os.Args[1:2], "")
-	} else if len(os.Args) > 2 {
-		fmt.Printf("Invalid number of arguments")
-		os.Exit(1)
-	} else {
+	switch len(os.Args) {
+	case 1:
 		rootDir = "."
+	case 2:
+		rootDir = strings.Join(os.Args[1:2], "")
+		_, err := os.Stat(rootDir)
+		if os.IsNotExist(err) {
+			fmt.Println("File does not exist")
+			os.Exit(1)
+		}
+		if err != nil {
+			fmt.Printf("Error %v", err)
+		}
+	default:
+		fmt.Printf("Usage: dirtree [directory]")
+		os.Exit(1)
 	}
 
 	fmt.Println(".")
 	printTree(rootDir, "", nil)
-
 }
 
 func shouldIgnore(path string, ignoreMatchers []*gitignore.GitIgnore) bool {

--- a/dirtree.go
+++ b/dirtree.go
@@ -15,6 +15,7 @@ func main() {
 	switch len(os.Args) {
 	case 1:
 		rootDir = "."
+		fmt.Println(".")
 	case 2:
 		rootDir = strings.Join(os.Args[1:2], "")
 		_, err := os.Stat(rootDir)
@@ -30,7 +31,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	fmt.Println(".")
 	printTree(rootDir, "", nil)
 }
 

--- a/dirtree.go
+++ b/dirtree.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/datumbrain/dirtree/internal/version"
 	gitignore "github.com/sabhiram/go-gitignore"
 )
 
@@ -17,21 +18,34 @@ func main() {
 		fmt.Println(".")
 	case 2:
 		rootDir = os.Args[1]
-		_, err := os.Stat(rootDir)
-		if os.IsNotExist(err) {
-			fmt.Println("directory does not exist")
+		if rootDir == "-v" || rootDir == "--version" {
+			PrintVersionInfo()
 			os.Exit(1)
-		}
-		if err != nil {
-			fmt.Println(fmt.Errorf("error: %v", err))
-			os.Exit(1)
+		} else {
+			_, err := os.Stat(rootDir)
+			if os.IsNotExist(err) {
+				fmt.Println("directory does not exist")
+				os.Exit(1)
+			}
+			if err != nil {
+				fmt.Println(fmt.Errorf("error: %v", err))
+				os.Exit(1)
+			}
 		}
 	default:
-		fmt.Println("Usage: dirtree [directory]")
+		fmt.Println("Usage: dirtree [directory | -v | --version]")
 		os.Exit(1)
 	}
 
 	printTree(rootDir, "", nil)
+
+}
+
+func PrintVersionInfo() {
+	versionInfo := version.Get()
+	fmt.Println(versionInfo.GitVersion)
+	fmt.Println(versionInfo.BuildDate)
+	fmt.Println(versionInfo.GitCommit)
 }
 
 func shouldIgnore(path string, ignoreMatchers []*gitignore.GitIgnore) bool {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,38 @@
+package version
+
+import (
+	"fmt"
+	"runtime"
+	"time"
+)
+
+var (
+	//x.y.z
+	//x - major release
+	//y - minor release
+	//z - build number
+	gitVersion = "v1.1.0-dirtree"
+	gitCommit  = ""
+	Time       = time.Now()
+	buildDate  = Time.String()
+)
+
+type VersionInfo struct {
+	GitVersion string `json:"gitVersion" yaml:"gitVersion"`
+	GitCommit  string `json:"gitCommit" yaml:"gitCommit"`
+	BuildDate  string `json:"buildDate" yaml:"buildDate"`
+	GoVersion  string `json:"goVersion" yaml:"goVersion"`
+	Compiler   string `json:"compiler" yaml:"compiler"`
+	Program    string `json:"program" yaml:"program"`
+}
+
+func Get() *VersionInfo {
+	return &VersionInfo{
+		GitVersion: gitVersion,
+		GitCommit:  gitCommit,
+		BuildDate:  buildDate,
+		GoVersion:  runtime.Version(),
+		Compiler:   runtime.Compiler,
+		Program:    fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}

--- a/runscript.sh
+++ b/runscript.sh
@@ -5,5 +5,4 @@ GIT_COMMIT="$(git rev-parse HEAD)"
 #VERSION="$(git describe --tags --abbrev=0 | tr -d "\n")"
 
 
-go generate ./...
-go build -o bin/main -ldflags="-X 'github.com/dirtree/internal/version.buildDate=${BUILD_DATE}'" *.go
+go build -o bin/main -ldflags="-X 'github.com/dirtree/internal/version.buildDate=${BUILD_DATE}' -X 'github.com/dirtree/internal/version.gitCommit=${GIT_COMMIT}'" *.go

--- a/runscript.sh
+++ b/runscript.sh
@@ -1,0 +1,9 @@
+#!/bin/zsh
+
+BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+GIT_COMMIT="$(git rev-parse HEAD)"
+#VERSION="$(git describe --tags --abbrev=0 | tr -d "\n")"
+
+
+go generate ./...
+go build -o bin/main -ldflags="-X 'github.com/dirtree/internal/version.buildDate=${BUILD_DATE}'" *.go


### PR DESCRIPTION
- Implemented command-line argument handling to allow specifying a directory path for printing the directory tree.
- Added validation to ensure only one argument is accepted; defaults to the current directory if no arguments are provided.
- Included error handling in case the directory does not exist.
- Included error handling for other cases.